### PR TITLE
Adding pre-programmed button support in quick replies.

### DIFF
--- a/config/Settings.ts
+++ b/config/Settings.ts
@@ -15,7 +15,7 @@ export enum AppSetting {
 
 export enum DefaultMessage {
     DEFAULT_DialogflowServiceUnavailableMessage = 'Sorry, I\'m having trouble answering your question.',
-    DEFAULT_DialogflowRequestFailedMessage = 'Apologies but your request cannot be completed.',
+    DEFAULT_DialogflowRequestFailedMessage = 'Sorry, something went wrong.',
     DEFAULT_DialogflowHandoverMessage = 'Transferring to an online agent',
     DEFAULT_DialogflowCloseChatMessage = 'Closing the chat, Goodbye',
 }

--- a/config/Settings.ts
+++ b/config/Settings.ts
@@ -15,6 +15,7 @@ export enum AppSetting {
 
 export enum DefaultMessage {
     DEFAULT_DialogflowServiceUnavailableMessage = 'Sorry, I\'m having trouble answering your question.',
+    DEFAULT_DialogflowRequestFailedMessage = 'Apologies but your request cannot be completed.',
     DEFAULT_DialogflowHandoverMessage = 'Transferring to an online agent',
     DEFAULT_DialogflowCloseChatMessage = 'Closing the chat, Goodbye',
 }

--- a/docs/QuickReplies.md
+++ b/docs/QuickReplies.md
@@ -75,30 +75,6 @@ These buttons perform a specific action in the app. You can add them by simply p
 }
 ```
 
-### Salesforce Handover Button
-
-- If you are using Salesforce Liveagent integration app along side your Dialogflow chatbot, then you can use this button payload to perform handover and initiate chat session with given Salesforce **buttonId**. Add the following block in your Quick Replies payload, with **actionId** set as `sf_handover_with_buttonid` and **salesforceButtonId** set to the buttonId of your Liveagent instance, to include this button in your response:
-
-- Parameters:
-
-|      Param Name      |  Dependency  | Param Type |       Acceptable Value      |
-|:--------------------:|:------------:|:----------:|:---------------------------:|
-|      `actionId`      | **Required** |   String   | `sf_handover_with_buttonid` |
-| `salesforceButtonId` | **Required** |   String   |  **Any Liveagent ButtonId** |
-|        `text`        | **Required** |   String   |           **Any**           |
-|     `buttonStyle`    | **Optional** |   String   |    `primary` or `danger`    |
-
-- Example Structure:
-
-```
-{
-   "text": "Perform Handover",
-   "salesforceButtonId": "5732w000000U9T6",
-   "actionId": "sf_handover_with_buttonid",
-   "buttonStyle": "danger"
-}
-```
-
 ## Example
 
 ![Pre-Programmed Example Payload](https://user-images.githubusercontent.com/41849970/92283593-d5e70a80-ef1d-11ea-8860-e91a4980515f.png)

--- a/docs/QuickReplies.md
+++ b/docs/QuickReplies.md
@@ -35,6 +35,16 @@ These buttons perform a specific action in the app. You can add them by simply p
 
 - On clicking this button, the visitor will be handed over to another departement. You can set the target department in the app setting called **Target Department for Handover**. Add the following block in your Quick Replies payload, with **actionId** set as `df_perform_handover`, to include this button in your response:
 
+- Parameters:
+
+|   Param Name  |  Dependency  | Param Type |    Acceptable Value   |
+|:-------------:|:------------:|:----------:|:---------------------:|
+|   `actionId`  | **Required** |   String   | `df_perform_handover` |
+|     `text`    | **Required** |   String   |        **Any**        |
+| `buttonStyle` | **Optional** |   String   | `primary` or `danger` |
+
+- Example Structure:
+
 ```
 {
    "text": "Perform Handover",
@@ -47,11 +57,45 @@ These buttons perform a specific action in the app. You can add them by simply p
 
 - When visitor clicks this button, the chat session will be closed. Add the following block in your Quick Replies payload, with **actionId** set as `df_close_chat`, to include this button in your response:
 
+- Parameters:
+
+|   Param Name  |  Dependency  | Param Type |    Acceptable Value   |
+|:-------------:|:------------:|:----------:|:---------------------:|
+|   `actionId`  | **Required** |   String   |    `df_close_chat`    |
+|     `text`    | **Required** |   String   |        **Any**        |
+| `buttonStyle` | **Optional** |   String   | `primary` or `danger` |
+
+- Example Structure:
+
 ```
 {
    "text": "Close Chat",
    "buttonStyle": "danger",
    "actionId": "df_close_chat"
+}
+```
+
+### Salesforce Handover Button
+
+- If you are using Salesforce Liveagent integration app along side your Dialogflow chatbot, then you can use this button payload to perform handover and initiate chat session with given Salesforce **buttonId**. Add the following block in your Quick Replies payload, with **actionId** set as `sf_handover_with_buttonid` and **salesforceButtonId** set to the buttonId of your Liveagent instance, to include this button in your response:
+
+- Parameters:
+
+|      Param Name      |  Dependency  | Param Type |       Acceptable Value      |
+|:--------------------:|:------------:|:----------:|:---------------------------:|
+|      `actionId`      | **Required** |   String   | `sf_handover_with_buttonid` |
+| `salesforceButtonId` | **Required** |   String   |  **Any Liveagent ButtonId** |
+|        `text`        | **Required** |   String   |           **Any**           |
+|     `buttonStyle`    | **Optional** |   String   |    `primary` or `danger`    |
+
+- Example Structure:
+
+```
+{
+   "text": "Perform Handover",
+   "salesforceButtonId": "5732w000000U9T6",
+   "actionId": "sf_handover_with_buttonid",
+   "buttonStyle": "danger"
 }
 ```
 

--- a/docs/QuickReplies.md
+++ b/docs/QuickReplies.md
@@ -37,11 +37,12 @@ These buttons perform a specific action in the app. You can add them by simply p
 
 - Parameters:
 
-|   Param Name  |  Dependency  | Param Type |    Acceptable Value   |
-|:-------------:|:------------:|:----------:|:---------------------:|
-|   `actionId`  | **Required** |   String   | `df_perform_handover` |
-|     `text`    | **Required** |   String   |        **Any**        |
-| `buttonStyle` | **Optional** |   String   | `primary` or `danger` |
+|    Param Name    |  Dependency  | Param Type |           Acceptable Value          |
+|:----------------:|:------------:|:----------:|:-----------------------------------:|
+|    `actionId`    | **Required** |   String   |        `df_perform_handover`        |
+|      `text`      | **Required** |   String   |               **Any**               |
+|   `buttonStyle`  | **Optional** |   String   |        `primary` or `danger`        |
+| `departmentName` | **Optional** |   String   | **Any Omnichannel department name** |
 
 - Example Structure:
 
@@ -49,7 +50,8 @@ These buttons perform a specific action in the app. You can add them by simply p
 {
    "text": "Perform Handover",
    "buttonStyle": "primary",
-   "actionId": "df_perform_handover"
+   "actionId": "df_perform_handover",
+   "departmentName": "sales"
 }
 ```
 
@@ -78,4 +80,3 @@ These buttons perform a specific action in the app. You can add them by simply p
 ## Example
 
 ![Pre-Programmed Example Payload](https://user-images.githubusercontent.com/41849970/92283593-d5e70a80-ef1d-11ea-8860-e91a4980515f.png)
-

--- a/docs/QuickReplies.md
+++ b/docs/QuickReplies.md
@@ -33,7 +33,9 @@ These buttons perform a specific action in the app. You can add them by simply p
 
 ### Handover Button
 
-- On clicking this button, the visitor will be handed over to another departement. You can set the target department in the app setting called **Target Department for Handover**. Add the following block in your Quick Replies payload, with **actionId** set as `df_perform_handover`, to include this button in your response:
+- On clicking this button, the visitor will be handed over to another departement. You can set the target department in the app setting called **Target Department for Handover** or add a `departmentName` param in your payload. On failing to provide a department name in either way, will send a request failure message back to the visitor, when visitor clicks the button. 
+
+- Add the following block in your Quick Replies payload, with **actionId** set as `df_perform_handover`, to include this button in your response:
 
 - Parameters:
 

--- a/docs/QuickReplies.md
+++ b/docs/QuickReplies.md
@@ -29,7 +29,7 @@
 
 ## Pre-Programmed Buttons
 
-This are buttons that performs specific actions in the app. You can add them by simply pasting the following block in your Quick Replies payload. **Note**: You can change the `text` and `buttonStyle` parameters as per your requirements, but only use the provided `actionId` for the button you want to add.
+These buttons perform a specific action in the app. You can add them by simply pasting the following block in your Quick Replies payload. **Note**: You can change the `text` and `buttonStyle` parameters as per your requirements, but only use the provided `actionId` for the button you want to add.
 
 ### Handover Button
 

--- a/docs/QuickReplies.md
+++ b/docs/QuickReplies.md
@@ -26,6 +26,36 @@
 |     `text`     |     String     |                                                            Title of the quick replies action.                                                            |    Required    |          Any          |       ``` "text": "Start Chat" ```      |
 |   `actionId`   |     String     |                                                              Id of the quick replies action.                                                             |    Optional    |          Any          | ``` "actionId": "sflaia-start-chat" ``` |
 |  `buttonStyle` |     String     | Button style of your quick replies action. Use `danger` to render a red colour action and `primary` for an action that matches your Livechat Bar colour. |    Optional    | `danger` or `primary` |     ``` "buttonStyle": "primary" ```    |
-### Example
 
-![Quick Replies Example](https://user-images.githubusercontent.com/41849970/91997140-62939c00-ed57-11ea-8b27-82e650a502f0.png)
+## Pre-Programmed Buttons
+
+This are buttons that performs specific actions in the app. You can add them by simply pasting the following block in your Quick Replies payload. **Note**: You can change the `text` and `buttonStyle` parameters as per your requirements, but only use the provided `actionId` for the button you want to add.
+
+### Handover Button
+
+- On clicking this button, the visitor will be handed over to another departement. You can set the target department in the app setting called **Target Department for Handover**. Add the following block in your Quick Replies payload, with **actionId** set as `df_perform_handover`, to include this button in your response:
+
+```
+{
+   "text": "Perform Handover",
+   "buttonStyle": "primary",
+   "actionId": "df_perform_handover"
+}
+```
+
+### Close Chat Button
+
+- When visitor clicks this button, the chat session will be closed. Add the following block in your Quick Replies payload, with **actionId** set as `df_close_chat`, to include this button in your response:
+
+```
+{
+   "text": "Close Chat",
+   "buttonStyle": "danger",
+   "actionId": "df_close_chat"
+}
+```
+
+## Example
+
+![Pre-Programmed Example Payload](https://user-images.githubusercontent.com/41849970/92283593-d5e70a80-ef1d-11ea-8860-e91a4980515f.png)
+

--- a/enum/ActionIds.ts
+++ b/enum/ActionIds.ts
@@ -1,4 +1,5 @@
 export enum ActionIds {
     PERFORM_HANDOVER = 'df_perform_handover',
     CLOSE_CHAT = 'df_close_chat',
+    SALESFORCE_BUTTON_ID_HANDOVER = 'sf_handover_with_buttonid',
 }

--- a/enum/ActionIds.ts
+++ b/enum/ActionIds.ts
@@ -1,0 +1,4 @@
+export enum ActionIds {
+    PERFORM_HANDOVER = 'df_perform_handover',
+    CLOSE_CHAT = 'df_close_chat',
+}

--- a/enum/ActionIds.ts
+++ b/enum/ActionIds.ts
@@ -1,5 +1,4 @@
 export enum ActionIds {
     PERFORM_HANDOVER = 'df_perform_handover',
     CLOSE_CHAT = 'df_close_chat',
-    SALESFORCE_BUTTON_ID_HANDOVER = 'sf_handover_with_buttonid',
 }

--- a/enum/Dialogflow.ts
+++ b/enum/Dialogflow.ts
@@ -15,7 +15,9 @@ export interface IDialogflowQuickReplyOptions {
     text: string;
     actionId?: string;
     buttonStyle?: ButtonStyle;
-    departmentName?: string;
+    data?: {
+        [prop: string]: any;
+    };
 }
 
 export interface IDialogflowAccessToken {

--- a/enum/Dialogflow.ts
+++ b/enum/Dialogflow.ts
@@ -15,6 +15,7 @@ export interface IDialogflowQuickReplyOptions {
     text: string;
     actionId?: string;
     buttonStyle?: ButtonStyle;
+    salesforceButtonId?: string;
 }
 
 export interface IDialogflowAccessToken {

--- a/enum/Dialogflow.ts
+++ b/enum/Dialogflow.ts
@@ -15,7 +15,6 @@ export interface IDialogflowQuickReplyOptions {
     text: string;
     actionId?: string;
     buttonStyle?: ButtonStyle;
-    salesforceButtonId?: string;
 }
 
 export interface IDialogflowAccessToken {

--- a/enum/Dialogflow.ts
+++ b/enum/Dialogflow.ts
@@ -15,6 +15,7 @@ export interface IDialogflowQuickReplyOptions {
     text: string;
     actionId?: string;
     buttonStyle?: ButtonStyle;
+    departmentName?: string;
 }
 
 export interface IDialogflowAccessToken {

--- a/handler/ExecuteLivechatBlockActionHandler.ts
+++ b/handler/ExecuteLivechatBlockActionHandler.ts
@@ -7,7 +7,7 @@ import { IUser } from '@rocket.chat/apps-engine/definition/users';
 import { AppSetting } from '../config/Settings';
 import { ActionIds } from '../enum/ActionIds';
 import { createLivechatMessage, deleteAllActionBlocks } from '../lib/Message';
-import { closeChat, performHandover, updateRoomCustomFields } from '../lib/Room';
+import { closeChat, performHandover } from '../lib/Room';
 import { getAppSettingValue } from '../lib/Settings';
 
 export class ExecuteLivechatBlockActionHandler {
@@ -44,12 +44,6 @@ export class ExecuteLivechatBlockActionHandler {
 
                 case ActionIds.CLOSE_CHAT:
                     await closeChat(this.modify, this.read, rid);
-                    break;
-
-                case ActionIds.SALESFORCE_BUTTON_ID_HANDOVER:
-                    const salesforceTargetDepartment: string = await getAppSettingValue(this.read, AppSetting.FallbackTargetDepartment);
-                    updateRoomCustomFields(rid, { reqButtonId: value }, this.read, this.modify);
-                    await performHandover(this.modify, this.read, rid, visitor.token, salesforceTargetDepartment);
                     break;
 
                 default:

--- a/handler/ExecuteLivechatBlockActionHandler.ts
+++ b/handler/ExecuteLivechatBlockActionHandler.ts
@@ -39,7 +39,6 @@ export class ExecuteLivechatBlockActionHandler {
             switch (actionId) {
                 case ActionIds.PERFORM_HANDOVER:
                     const targetDepartment: string = value || await getAppSettingValue(this.read, AppSetting.FallbackTargetDepartment);
-                    if (value !== undefined) { targetDepartment = value; }
                     if (!targetDepartment) {
                         await createMessage(rid, this.read, this.modify, { text: DefaultMessage.DEFAULT_DialogflowRequestFailedMessage });
                         break;

--- a/handler/ExecuteLivechatBlockActionHandler.ts
+++ b/handler/ExecuteLivechatBlockActionHandler.ts
@@ -7,7 +7,7 @@ import { IUser } from '@rocket.chat/apps-engine/definition/users';
 import { AppSetting } from '../config/Settings';
 import { ActionIds } from '../enum/ActionIds';
 import { createLivechatMessage, deleteAllActionBlocks } from '../lib/Message';
-import { closeChat, performHandover } from '../lib/Room';
+import { closeChat, performHandover, updateRoomCustomFields } from '../lib/Room';
 import { getAppSettingValue } from '../lib/Settings';
 
 export class ExecuteLivechatBlockActionHandler {
@@ -44,6 +44,12 @@ export class ExecuteLivechatBlockActionHandler {
 
                 case ActionIds.CLOSE_CHAT:
                     await closeChat(this.modify, this.read, rid);
+                    break;
+
+                case ActionIds.SALESFORCE_BUTTON_ID_HANDOVER:
+                    const salesforceTargetDepartment: string = await getAppSettingValue(this.read, AppSetting.FallbackTargetDepartment);
+                    updateRoomCustomFields(rid, { reqButtonId: value }, this.read, this.modify);
+                    await performHandover(this.modify, this.read, rid, visitor.token, salesforceTargetDepartment);
                     break;
 
                 default:

--- a/handler/ExecuteLivechatBlockActionHandler.ts
+++ b/handler/ExecuteLivechatBlockActionHandler.ts
@@ -4,9 +4,9 @@ import { ILivechatRoom } from '@rocket.chat/apps-engine/definition/livechat';
 import { IUIKitResponse, UIKitLivechatBlockInteractionContext } from '@rocket.chat/apps-engine/definition/uikit';
 import { UIKitIncomingInteractionContainerType } from '@rocket.chat/apps-engine/definition/uikit/UIKitIncomingInteractionContainer';
 import { IUser } from '@rocket.chat/apps-engine/definition/users';
-import { AppSetting } from '../config/Settings';
+import { AppSetting, DefaultMessage } from '../config/Settings';
 import { ActionIds } from '../enum/ActionIds';
-import { createLivechatMessage, deleteAllActionBlocks } from '../lib/Message';
+import { createLivechatMessage, createMessage, deleteAllActionBlocks } from '../lib/Message';
 import { closeChat, performHandover } from '../lib/Room';
 import { getAppSettingValue } from '../lib/Settings';
 
@@ -38,7 +38,12 @@ export class ExecuteLivechatBlockActionHandler {
 
             switch (actionId) {
                 case ActionIds.PERFORM_HANDOVER:
-                    const targetDepartment: string = await getAppSettingValue(this.read, AppSetting.FallbackTargetDepartment);
+                    let targetDepartment: string = await getAppSettingValue(this.read, AppSetting.FallbackTargetDepartment);
+                    if (value !== undefined) { targetDepartment = value; }
+                    if (!targetDepartment) {
+                        await createMessage(rid, this.read, this.modify, { text: DefaultMessage.DEFAULT_DialogflowRequestFailedMessage });
+                        break;
+                    }
                     await performHandover(this.modify, this.read, rid, visitor.token, targetDepartment);
                     break;
 

--- a/handler/ExecuteLivechatBlockActionHandler.ts
+++ b/handler/ExecuteLivechatBlockActionHandler.ts
@@ -38,7 +38,7 @@ export class ExecuteLivechatBlockActionHandler {
 
             switch (actionId) {
                 case ActionIds.PERFORM_HANDOVER:
-                    let targetDepartment: string = await getAppSettingValue(this.read, AppSetting.FallbackTargetDepartment);
+                    const targetDepartment: string = value || await getAppSettingValue(this.read, AppSetting.FallbackTargetDepartment);
                     if (value !== undefined) { targetDepartment = value; }
                     if (!targetDepartment) {
                         await createMessage(rid, this.read, this.modify, { text: DefaultMessage.DEFAULT_DialogflowRequestFailedMessage });

--- a/lib/Message.ts
+++ b/lib/Message.ts
@@ -20,7 +20,7 @@ export const createDialogflowMessage = async (rid: string, read: IRead,  modify:
                     type: TextObjectType.PLAINTEXT,
                     text: payload.text,
                 },
-                value: payload.salesforceButtonId ? payload.salesforceButtonId : payload.text,
+                value: payload.text,
                 actionId: payload.actionId || uuid(),
                 ...payload.buttonStyle && { style: payload.buttonStyle },
             } as IButtonElement));

--- a/lib/Message.ts
+++ b/lib/Message.ts
@@ -23,7 +23,7 @@ export const createDialogflowMessage = async (rid: string, read: IRead,  modify:
                             text: payload.text,
                             type: TextObjectType.PLAINTEXT,
                         },
-                        value: payload.text,
+                        value: payload.actionId && payload.actionId === ActionIds.PERFORM_HANDOVER ? payload.departmentName : payload.text,,
                         ...payload.buttonStyle && { style: payload.buttonStyle },
                     };
 

--- a/lib/Message.ts
+++ b/lib/Message.ts
@@ -28,7 +28,7 @@ export const createDialogflowMessage = async (rid: string, read: IRead,  modify:
                     };
 
                     if (payload.actionId && payload.actionId === ActionIds.PERFORM_HANDOVER) {
-                        buttonElement.value = payload.departmentName ? payload.departmentName : undefined;
+                        buttonElement.value = payload.data && payload.data.departmentName ? payload.data.departmentName : undefined;
                     }
 
                     return buttonElement;

--- a/lib/Message.ts
+++ b/lib/Message.ts
@@ -3,6 +3,7 @@ import { IVisitor } from '@rocket.chat/apps-engine/definition/livechat';
 import { BlockElementType, BlockType, IActionsBlock, IButtonElement, TextObjectType } from '@rocket.chat/apps-engine/definition/uikit';
 import { IUser } from '@rocket.chat/apps-engine/definition/users';
 import { AppSetting } from '../config/Settings';
+import { ActionIds } from '../enum/ActionIds';
 import { IDialogflowMessage, IDialogflowQuickReplies, IDialogflowQuickReplyOptions } from '../enum/Dialogflow';
 import { Logs } from '../enum/Logs';
 import { uuid } from './Helper';
@@ -14,16 +15,33 @@ export const createDialogflowMessage = async (rid: string, read: IRead,  modify:
     for (const message of messages) {
         const { text, options } = message as IDialogflowQuickReplies;
         if (text && options) {
-            const elements: Array<IButtonElement> = options.map((payload: IDialogflowQuickReplyOptions) => ({
-                type: BlockElementType.BUTTON,
-                text: {
-                    type: TextObjectType.PLAINTEXT,
-                    text: payload.text,
-                },
-                value: payload.text,
-                actionId: payload.actionId || uuid(),
-                ...payload.buttonStyle && { style: payload.buttonStyle },
-            } as IButtonElement));
+            const elements: Array<IButtonElement> = options.map((payload: IDialogflowQuickReplyOptions) => {
+                if (payload.actionId && payload.actionId === ActionIds.PERFORM_HANDOVER) {
+                    const buttonElement: IButtonElement = {
+                        type: BlockElementType.BUTTON,
+                        actionId: payload.actionId || uuid(),
+                        text: {
+                            text: payload.text,
+                            type: TextObjectType.PLAINTEXT,
+                        },
+                        value: payload.departmentName ? payload.departmentName : undefined,
+                        ...payload.buttonStyle && { style: payload.buttonStyle },
+                    };
+                    return buttonElement;
+                } else {
+                    const buttonElement: IButtonElement = {
+                        type: BlockElementType.BUTTON,
+                        actionId: payload.actionId || uuid(),
+                        text: {
+                            text: payload.text,
+                            type: TextObjectType.PLAINTEXT,
+                        },
+                        value: payload.text,
+                        ...payload.buttonStyle && { style: payload.buttonStyle },
+                    };
+                    return buttonElement;
+                }
+            });
 
             const actionsBlock: IActionsBlock = { type: BlockType.ACTIONS, elements };
 

--- a/lib/Message.ts
+++ b/lib/Message.ts
@@ -20,7 +20,7 @@ export const createDialogflowMessage = async (rid: string, read: IRead,  modify:
                     type: TextObjectType.PLAINTEXT,
                     text: payload.text,
                 },
-                value: payload.text,
+                value: payload.salesforceButtonId ? payload.salesforceButtonId : payload.text,
                 actionId: payload.actionId || uuid(),
                 ...payload.buttonStyle && { style: payload.buttonStyle },
             } as IButtonElement));

--- a/lib/Message.ts
+++ b/lib/Message.ts
@@ -16,19 +16,6 @@ export const createDialogflowMessage = async (rid: string, read: IRead,  modify:
         const { text, options } = message as IDialogflowQuickReplies;
         if (text && options) {
             const elements: Array<IButtonElement> = options.map((payload: IDialogflowQuickReplyOptions) => {
-                if (payload.actionId && payload.actionId === ActionIds.PERFORM_HANDOVER) {
-                    const buttonElement: IButtonElement = {
-                        type: BlockElementType.BUTTON,
-                        actionId: payload.actionId || uuid(),
-                        text: {
-                            text: payload.text,
-                            type: TextObjectType.PLAINTEXT,
-                        },
-                        value: payload.departmentName ? payload.departmentName : undefined,
-                        ...payload.buttonStyle && { style: payload.buttonStyle },
-                    };
-                    return buttonElement;
-                } else {
                     const buttonElement: IButtonElement = {
                         type: BlockElementType.BUTTON,
                         actionId: payload.actionId || uuid(),
@@ -39,8 +26,12 @@ export const createDialogflowMessage = async (rid: string, read: IRead,  modify:
                         value: payload.text,
                         ...payload.buttonStyle && { style: payload.buttonStyle },
                     };
+
+                    if (payload.actionId && payload.actionId === ActionIds.PERFORM_HANDOVER) {
+                        buttonElement.value = payload.departmentName ? payload.departmentName : undefined;
+                    }
+
                     return buttonElement;
-                }
             });
 
             const actionsBlock: IActionsBlock = { type: BlockType.ACTIONS, elements };

--- a/lib/Message.ts
+++ b/lib/Message.ts
@@ -23,7 +23,7 @@ export const createDialogflowMessage = async (rid: string, read: IRead,  modify:
                             text: payload.text,
                             type: TextObjectType.PLAINTEXT,
                         },
-                        value: payload.actionId && payload.actionId === ActionIds.PERFORM_HANDOVER ? payload.departmentName : payload.text,,
+                        value: payload.text,
                         ...payload.buttonStyle && { style: payload.buttonStyle },
                     };
 


### PR DESCRIPTION
This PR adds support for buttons that perform a specific action in the app - `Handover` and `Close Chat`. Anyone can add them by simply pasting the provided code blocks in your Quick Replies payload.

This way the dev will only have to paste a block with particular **actionId** set as `df_perform_handover` and when a visitor clicks on it, it will perform handover to Target department set in App settings. Similarly, on clicking the button with **actionId** = `df_close_chat`, it will close the Live Chat session.

## Payload Example

![Example-Dialogflow-Pre-Programmed-Buttons](https://user-images.githubusercontent.com/41849970/92284972-d1702100-ef20-11ea-9c90-54a82bed87ff.png)
