### PR TITLE
Handover Endpoint - Throw error when no agents are online

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,6 +1,6 @@
 {
     "id": "21b7d3ba-031b-41d9-8ff2-fbbfa081ae90",
-    "version": "1.2.1",
+    "version": "1.2.2",
     "requiredApiVersion": "^1.17.0",
     "iconFile": "icon.png",
     "author": {

--- a/app.json
+++ b/app.json
@@ -1,6 +1,6 @@
 {
     "id": "21b7d3ba-031b-41d9-8ff2-fbbfa081ae90",
-    "version": "1.2.2",
+    "version": "1.2.3",
     "requiredApiVersion": "^1.17.0",
     "iconFile": "icon.png",
     "author": {

--- a/config/Settings.ts
+++ b/config/Settings.ts
@@ -9,6 +9,7 @@ export enum AppSetting {
     FallbackTargetDepartment = 'fallback_target_department',
     DialogflowHandoverMessage = 'dialogflow_handover_message',
     DialogflowServiceUnavailableMessage = 'dialogflow_service_unavailable_message',
+    DialogflowHandoverFailedMessage = 'dialogflow_no_agents_online_for_handover',
     DialogflowCloseChatMessage = 'dialogflow_close_chat_message',
     DialogflowHideQuickReplies = 'dialogflow_hide_quick_replies',
 }
@@ -17,6 +18,7 @@ export enum DefaultMessage {
     DEFAULT_DialogflowServiceUnavailableMessage = 'Sorry, I\'m having trouble answering your question.',
     DEFAULT_DialogflowRequestFailedMessage = 'Sorry, something went wrong.',
     DEFAULT_DialogflowHandoverMessage = 'Transferring to an online agent',
+    DEFAULT_DialogflowHandoverFailedMessage = 'Sorry couldn\'t find any agent online at this moment.',
     DEFAULT_DialogflowCloseChatMessage = 'Closing the chat, Goodbye',
 }
 
@@ -79,6 +81,15 @@ export const settings: Array<ISetting> = [
         packageValue: '',
         i18nLabel: 'dialogflow_handover_message',
         i18nDescription: 'dialogflow_handover_message_description',
+        required: false,
+    },
+    {
+        id: AppSetting.DialogflowHandoverFailedMessage,
+        public: true,
+        type: SettingType.STRING,
+        packageValue: '',
+        i18nLabel: 'dialogflow_handover_failed_message',
+        i18nDescription: 'dialogflow_handover_failed_message_description',
         required: false,
     },
     {

--- a/config/Settings.ts
+++ b/config/Settings.ts
@@ -18,7 +18,6 @@ export enum DefaultMessage {
     DEFAULT_DialogflowServiceUnavailableMessage = 'Sorry, I\'m having trouble answering your question.',
     DEFAULT_DialogflowRequestFailedMessage = 'Sorry, something went wrong.',
     DEFAULT_DialogflowHandoverMessage = 'Transferring to an online agent',
-    DEFAULT_DialogflowHandoverFailedMessage = 'Sorry couldn\'t find any agent online at this moment.',
     DEFAULT_DialogflowCloseChatMessage = 'Closing the chat, Goodbye',
 }
 

--- a/endpoints/IncomingEndpoint.ts
+++ b/endpoints/IncomingEndpoint.ts
@@ -22,7 +22,7 @@ export class IncomingEndpoint extends ApiEndpoint {
         this.app.getLogger().info(Logs.ENDPOINT_RECEIVED_REQUEST);
 
         try {
-            const { statusCode = HttpStatusCode.OK, data } = await this.processRequest(read, modify, http, request.content) || {};
+            const { statusCode = HttpStatusCode.OK, data = null } = await this.processRequest(read, modify, http, request.content);
             return createHttpResponse(statusCode, { 'Content-Type': Headers.CONTENT_TYPE_JSON }, { ...data ? { ...data } : { result: Response.SUCCESS } });
         } catch (error) {
             this.app.getLogger().error(Logs.ENDPOINT_REQUEST_PROCESSING_ERROR, error);
@@ -44,7 +44,7 @@ export class IncomingEndpoint extends ApiEndpoint {
             case EndpointActionNames.HANDOVER:
                 const { actionData: { targetDepartment = '' } = {} } = endpointContent;
                 const room = await read.getRoomReader().getById(sessionId) as ILivechatRoom;
-                if (!room) { throw new Error(); }
+                if (!room || !room.isOpen) { throw new Error('Error! Invalid session Id. No active room found with the given session id'); }
                 const { visitor: { token: visitorToken } } = room;
                 const result = await performHandover(this.app, modify, read, sessionId, visitorToken, targetDepartment);
                 if (!result) {

--- a/endpoints/IncomingEndpoint.ts
+++ b/endpoints/IncomingEndpoint.ts
@@ -1,7 +1,7 @@
 import { HttpStatusCode, IHttp, IModify, IPersistence, IRead } from '@rocket.chat/apps-engine/definition/accessors';
 import { ApiEndpoint, IApiEndpointInfo, IApiRequest, IApiResponse } from '@rocket.chat/apps-engine/definition/api';
 import { ILivechatRoom } from '@rocket.chat/apps-engine/definition/livechat';
-import { IDialogflowMessage, DialogflowRequestType } from '../enum/Dialogflow';
+import { DialogflowRequestType, IDialogflowMessage } from '../enum/Dialogflow';
 import { EndpointActionNames, IActionsEndpointContent } from '../enum/Endpoints';
 import { Headers, Response } from '../enum/Http';
 import { Logs } from '../enum/Logs';
@@ -43,7 +43,10 @@ export class IncomingEndpoint extends ApiEndpoint {
                 const room = await read.getRoomReader().getById(sessionId) as ILivechatRoom;
                 if (!room) { throw new Error(); }
                 const { visitor: { token: visitorToken } } = room;
-                await performHandover(modify, read, sessionId, visitorToken, targetDepartment);
+                const result = await performHandover(modify, read, sessionId, visitorToken, targetDepartment);
+                if (!result) {
+                    throw new Error(Logs.NO_AGENTS_ONLINE);
+                }
                 break;
             case EndpointActionNames.TRIGGER_EVENT:
                 const { actionData: { event = null } = {} } = endpointContent;

--- a/enum/Http.ts
+++ b/enum/Http.ts
@@ -6,4 +6,5 @@ export enum Headers {
 
 export enum Response {
     SUCCESS = 'Your request was processed successfully',
+    NO_AGENTS_ONLINE = 'Handover failed! No agents online',
 }

--- a/enum/Logs.ts
+++ b/enum/Logs.ts
@@ -20,4 +20,5 @@ export enum Logs {
     HTTP_REQUEST_ERROR = 'Error occurred while sending a HTTP Request',
     CLOSE_CHAT_REQUEST_FAILED_ERROR = 'Error: Internal Server Error. Could not close the chat',
     HANDOVER_REQUEST_FAILED_ERROR = 'Error occurred while processing handover. Details',
+    NO_AGENTS_ONLINE = 'Handover failed! No agents online',
 }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -14,5 +14,7 @@
     "dialogflow_close_chat_message": "Close Chat Message",
     "dialogflow_close_chat_message_description": "This message will be sent automatically when a chat is closed",
     "dialogflow_hide_quick_replies": "Hide Quick Replies",
-    "dialogflow_hide_quick_replies_description": "If enabled, then all quick-replies will hide when a visitor clicks on any one of them"
+    "dialogflow_hide_quick_replies_description": "If enabled, then all quick-replies will hide when a visitor clicks on any one of them",
+    "dialogflow_handover_failed_message": "Handover Failed Message",
+    "dialogflow_handover_failed_message_description": "The Bot will send this message to Visitor if the handover failed because no agents were online"
 }

--- a/lib/Room.ts
+++ b/lib/Room.ts
@@ -43,7 +43,7 @@ export const closeChat = async (modify: IModify, read: IRead, rid: string) => {
     if (!result) { throw new Error(Logs.CLOSE_CHAT_REQUEST_FAILED_ERROR); }
 };
 
-export const performHandover = async (modify: IModify, read: IRead, rid: string, visitorToken: string, targetDepartmentName?: string): Promise<boolean> => {
+export const performHandover = async (app: IApp, modify: IModify, read: IRead, rid: string, visitorToken: string, targetDepartmentName?: string): Promise<boolean> => {
     const handoverMessage: string = await getAppSettingValue(read, AppSetting.DialogflowHandoverMessage);
     await createMessage(app, rid, read, modify, { text: handoverMessage ? handoverMessage : DefaultMessage.DEFAULT_DialogflowHandoverMessage });
 
@@ -70,7 +70,9 @@ export const performHandover = async (modify: IModify, read: IRead, rid: string,
         });
     if (!result) {
         const offlineMessage: string = await getAppSettingValue(read, AppSetting.DialogflowHandoverFailedMessage);
-        await createMessage(rid, read, modify, { text: offlineMessage ? offlineMessage : DefaultMessage.DEFAULT_DialogflowHandoverFailedMessage });
+        if (offlineMessage && offlineMessage.trim()) {
+            await createMessage(app, rid, read, modify, { text: offlineMessage ? offlineMessage : DefaultMessage.DEFAULT_DialogflowHandoverFailedMessage });
+        }
 
         return false;
     }

--- a/lib/Room.ts
+++ b/lib/Room.ts
@@ -44,9 +44,6 @@ export const closeChat = async (modify: IModify, read: IRead, rid: string) => {
 };
 
 export const performHandover = async (app: IApp, modify: IModify, read: IRead, rid: string, visitorToken: string, targetDepartmentName?: string): Promise<boolean> => {
-    const handoverMessage: string = await getAppSettingValue(read, AppSetting.DialogflowHandoverMessage);
-    await createMessage(app, rid, read, modify, { text: handoverMessage ? handoverMessage : DefaultMessage.DEFAULT_DialogflowHandoverMessage });
-
     const room: ILivechatRoom = (await read.getRoomReader().getById(rid)) as ILivechatRoom;
     if (!room) { throw new Error(Logs.INVALID_ROOM_ID); }
 
@@ -64,6 +61,19 @@ export const performHandover = async (app: IApp, modify: IModify, read: IRead, r
         livechatTransferData.targetDepartment = targetDepartment.id;
     }
 
+    // check if any agent is online in the department where we're transferring this chat
+    const serviceOnline = await read.getLivechatReader().isOnlineAsync(livechatTransferData.targetDepartment);
+    if (!serviceOnline) {
+        const offlineMessage: string = await getAppSettingValue(read, AppSetting.DialogflowHandoverFailedMessage);
+        if (offlineMessage && offlineMessage.trim()) {
+            await createMessage(app, rid, read, modify, { text: offlineMessage });
+        }
+        return false;
+    }
+
+    const handoverMessage: string = await getAppSettingValue(read, AppSetting.DialogflowHandoverMessage);
+    await createMessage(app, rid, read, modify, { text: handoverMessage ? handoverMessage : DefaultMessage.DEFAULT_DialogflowHandoverMessage });
+
     const result = await modify.getUpdater().getLivechatUpdater().transferVisitor(visitor, livechatTransferData)
         .catch((error) => {
             throw new Error(`${Logs.HANDOVER_REQUEST_FAILED_ERROR} ${error}`);
@@ -71,7 +81,7 @@ export const performHandover = async (app: IApp, modify: IModify, read: IRead, r
     if (!result) {
         const offlineMessage: string = await getAppSettingValue(read, AppSetting.DialogflowHandoverFailedMessage);
         if (offlineMessage && offlineMessage.trim()) {
-            await createMessage(app, rid, read, modify, { text: offlineMessage ? offlineMessage : DefaultMessage.DEFAULT_DialogflowHandoverFailedMessage });
+            await createMessage(app, rid, read, modify, { text: offlineMessage });
         }
 
         return false;

--- a/lib/Room.ts
+++ b/lib/Room.ts
@@ -42,7 +42,7 @@ export const closeChat = async (modify: IModify, read: IRead, rid: string) => {
     if (!result) { throw new Error(Logs.CLOSE_CHAT_REQUEST_FAILED_ERROR); }
 };
 
-export const performHandover = async (modify: IModify, read: IRead, rid: string, visitorToken: string, targetDepartmentName?: string) => {
+export const performHandover = async (modify: IModify, read: IRead, rid: string, visitorToken: string, targetDepartmentName?: string): Promise<boolean> => {
 
     const handoverMessage: string = await getAppSettingValue(read, AppSetting.DialogflowHandoverMessage);
     await createMessage(rid, read, modify, { text: handoverMessage ? handoverMessage : DefaultMessage.DEFAULT_DialogflowHandoverMessage });
@@ -73,6 +73,7 @@ export const performHandover = async (modify: IModify, read: IRead, rid: string,
 
         await createMessage(rid, read, modify, { text: offlineMessage ? offlineMessage : DefaultMessage.DEFAULT_DialogflowServiceUnavailableMessage });
 
-        throw new Error(Logs.NO_AGENTS_ONLINE);
+        return false;
     }
+    return true;
 };

--- a/lib/Room.ts
+++ b/lib/Room.ts
@@ -69,9 +69,9 @@ export const performHandover = async (modify: IModify, read: IRead, rid: string,
             throw new Error(`${Logs.HANDOVER_REQUEST_FAILED_ERROR} ${error}`);
         });
     if (!result) {
-        const offlineMessage: string = await getAppSettingValue(read, AppSetting.DialogflowServiceUnavailableMessage);
+        const offlineMessage: string = await getAppSettingValue(read, AppSetting.DialogflowHandoverFailedMessage);
 
-        await createMessage(rid, read, modify, { text: offlineMessage ? offlineMessage : DefaultMessage.DEFAULT_DialogflowServiceUnavailableMessage });
+        await createMessage(rid, read, modify, { text: offlineMessage ? offlineMessage : DefaultMessage.DEFAULT_DialogflowHandoverFailedMessage });
 
         return false;
     }

--- a/lib/Room.ts
+++ b/lib/Room.ts
@@ -72,5 +72,7 @@ export const performHandover = async (modify: IModify, read: IRead, rid: string,
         const offlineMessage: string = await getAppSettingValue(read, AppSetting.DialogflowServiceUnavailableMessage);
 
         await createMessage(rid, read, modify, { text: offlineMessage ? offlineMessage : DefaultMessage.DEFAULT_DialogflowServiceUnavailableMessage });
+
+        throw new Error(Logs.NO_AGENTS_ONLINE);
     }
 };


### PR DESCRIPTION
### Old behaviour:
If the handover fails and no agents were online, the endpoint would **not** throw any error and would return same **200** OK status code

### New Behaviour:
If the handover fails because no agents were online, the endpoint will throw an error 
Response status code: **409**
Response body: `{ "error": "Handover failed! No agents online" }`

Plus, we're introducing a new setting where a admin can configure a custom message to be sent to the visitor, incase a handover attempt is failed