### PR TITLE
[IMPROVE] Increase log verbosity

### DIFF
--- a/lib/Dialogflow.ts
+++ b/lib/Dialogflow.ts
@@ -5,7 +5,7 @@ import { AppSetting } from '../config/Settings';
 import { DialogflowJWT, DialogflowRequestType, DialogflowUrl, IDialogflowAccessToken, IDialogflowEvent, IDialogflowMessage, IDialogflowQuickReplies, LanguageCode } from '../enum/Dialogflow';
 import { Headers } from '../enum/Http';
 import { Logs } from '../enum/Logs';
-import { base64urlEncode } from './Helper';
+import { base64urlEncode, stringifyError } from './Helper';
 import { createHttpRequest } from './Http';
 import { updateRoomCustomFields } from './Room';
 import { getAppSettingValue } from './Settings';
@@ -41,7 +41,7 @@ class DialogflowClass {
 
             return this.parseRequest(response.data);
         } catch (error) {
-            throw new Error(`${ Logs.HTTP_REQUEST_ERROR }. Details: ${ error.message }. Raw Error: ${ JSON.stringify(error, Object.getOwnPropertyNames(error)) }`);
+            throw new Error(`${ Logs.HTTP_REQUEST_ERROR }. Details: ${ error.message }. Raw Error: ${ stringifyError(error) }`);
         }
     }
 
@@ -173,7 +173,7 @@ class DialogflowClass {
 
             return accessToken.token;
         } catch (error) {
-            throw Error(`${ Logs.ACCESS_TOKEN_ERROR }. Raw Error: ${ JSON.stringify(error, Object.getOwnPropertyNames(error)) }`);
+            throw Error(`${ Logs.ACCESS_TOKEN_ERROR }. Raw Error: ${ stringifyError(error) }`);
         }
     }
 

--- a/lib/Dialogflow.ts
+++ b/lib/Dialogflow.ts
@@ -32,9 +32,16 @@ class DialogflowClass {
 
         try {
             const response = await http.post(serverURL, httpRequestContent);
+            if (!response) {
+                throw new Error('Failed to get any response from the Dialogflow api. Please check if you server is able to connect to public n/w');
+            }
+            if (!response.statusCode.toString().startsWith('2') || !response.data) {
+                throw new Error(`Invalid response received from Dialogflow api. Response: ${ response.content }`);
+            }
+
             return this.parseRequest(response.data);
         } catch (error) {
-            throw new Error(`${ Logs.HTTP_REQUEST_ERROR }`);
+            throw new Error(`${ Logs.HTTP_REQUEST_ERROR }. Details: ${ error.message }. Raw Error: ${ JSON.stringify(error, Object.getOwnPropertyNames(error)) }`);
         }
     }
 
@@ -166,7 +173,7 @@ class DialogflowClass {
 
             return accessToken.token;
         } catch (error) {
-            throw Error(Logs.ACCESS_TOKEN_ERROR + error);
+            throw Error(`${ Logs.ACCESS_TOKEN_ERROR }. Raw Error: ${ JSON.stringify(error, Object.getOwnPropertyNames(error)) }`);
         }
     }
 

--- a/lib/Helper.ts
+++ b/lib/Helper.ts
@@ -44,3 +44,5 @@ export const uuid = (): string => {
 export const escapeRegExp = (str: string): string => {
     return str.replace(/[.*+?^${}()|[\]\\\/]/g, '\\$&'); // $& means the whole matched string
 };
+
+export const stringifyError = (error: Error): string => (JSON.stringify(error, Object.getOwnPropertyNames(error)));


### PR DESCRIPTION
Right now, if Dialogflow's HTTP request fails, then we don't log any details about it within the logs. That makes it difficult to debug any issue. So now, in this PR, we're adding some additional information to the records, mainly the response of the HTTP request - which should ideally tell us why the request failed